### PR TITLE
Modify SanBuilder.TryParse to set the output san value

### DIFF
--- a/ChessLibrary/Builders/SanBuilder.cs
+++ b/ChessLibrary/Builders/SanBuilder.cs
@@ -204,6 +204,7 @@ internal static class SanBuilder
         else if (move.IsMate) builder.Append('$');
 
         move.San = builder.ToString();
+        san = builder.ToString();
 
         return (true, null);
     }

--- a/ChessUnitTests/UnitTests.cs
+++ b/ChessUnitTests/UnitTests.cs
@@ -97,6 +97,19 @@ public class UnitChessTests
     }
 
     [Fact]
+    public void TestParseToSan()
+    {
+        var board = new ChessBoard();
+        var move = new Move("e2", "e4");
+        Assert.True(board.IsValidMove(move));
+
+        string? san;
+        Assert.True(board.TryParseToSan(move, out san));
+        Assert.NotNull(san);
+        Assert.Equal("e4", san);
+    }
+
+    [Fact]
     public void TestCapturedPieces()
     {
         var board = new ChessBoard();


### PR DESCRIPTION
Calls to `Chessboard.ParseToSan` and `Chessboard.TryParseToSan` resulted in `null` for the output `san` string - even when the `Move` provided is determined valid.

This PR fixes the `SanBuilder.TryParse` method to set the output `san` string which, in turn, bubbles up through the `Chessboard.*ParseToSan` methods and, I believe, is the expected behaviour.

I've also added a test to illustrate the expected behaviour.

Fixes #5 
