### PR TITLE
Fix for Moves() returning a promotion to Queen with a null San

### DIFF
--- a/Chess.Tests/MoveTests.cs
+++ b/Chess.Tests/MoveTests.cs
@@ -447,4 +447,17 @@ public class MoveTests
 
         Assert.Equal(fen, board.ToFen());
     }
+
+    [Fact]
+    public void Moves_QueenPromotion_ShouldHaveSan()
+    {
+        var board = ChessBoard.LoadFromFen("8/6P1/8/2k5/8/8/8/K7 w - - 0 1");
+        var moves = board.Moves(generateSan: true);
+
+        Assert.All(moves, m => Assert.NotNull(m.San));
+
+        var move = moves.Single(m => m.NewPosition == new Position("g8") && m.Parameter is MovePromotion mp && mp.PromotionType == PromotionType.ToQueen);
+
+        Assert.Equal("g8=Q", move.San);
+    }
 }

--- a/ChessLibrary/ChessBoard/ChessGenerations.cs
+++ b/ChessLibrary/ChessBoard/ChessGenerations.cs
@@ -66,6 +66,10 @@ public partial class ChessBoard
         if (skipPromotion == PromotionType.Default) skipPromotion = PromotionType.ToQueen;
         
         moves.Add(new Move(move, skipPromotion));
+        if (generateSan)
+        {
+            ParseToSan(moves[^1]);
+        }
 
         // IsCheck and IsMate depends on promotion type so we have to reset those properties for each promotion type
         var promotions = new List<PromotionType>


### PR DESCRIPTION
Including a unit test that fails before this fix: out of 7 moves, 6 have a non-null SAN and one is null.