### PR TITLE
Fix end game detection when a castling escape is theoretically possible

### DIFF
--- a/Chess.Tests/EndGameTests.cs
+++ b/Chess.Tests/EndGameTests.cs
@@ -131,5 +131,15 @@ public class EndGameTests
         Assert.True(board.IsEndGame); // same board but with white to move, it's a stalemate
         Assert.Equal(EndgameType.Stalemate, board.EndGame.EndgameType);
     }
+
+    [Fact]
+    public void EndGame_Checkmate_CastlingEscape()
+    {
+        var board = ChessBoard.LoadFromFen("rn1qk2r/ppp1bQpp/5n2/4N3/3pP3/8/PP3PPP/RNB1K2R b KQ - 0 1", AutoEndgameRules.All);
+        Assert.True(board.IsEndGame);
+        Assert.NotNull(board.EndGame);
+        Assert.Equal(EndgameType.Checkmate, board.EndGame.EndgameType);
+        Assert.Equal(PieceColor.White, board.EndGame.WonSide);
+    }
 }
 

--- a/ChessLibrary/ChessBoard/ChessValidations.cs
+++ b/ChessLibrary/ChessBoard/ChessValidations.cs
@@ -1,4 +1,4 @@
-﻿// *****************************************************
+// *****************************************************
 // *                                                   *
 // * O Lord, Thank you for your goodness in our lives. *
 // *     Please bless this code to our compilers.      *
@@ -225,6 +225,7 @@ public partial class ChessBoard
                     foreach (var position in GeneratePositions(fromPosition, board))
                     {
                         var move = new Move(fromPosition, position) { Piece = board.pieces[i, j]! };
+                        board.IsValidMove(move);
                         if (!IsKingCheckedValidation(move, side, board))
                             return true;
                     }
@@ -391,52 +392,48 @@ public partial class ChessBoard
                         // Queen Castle
                         if (move.NewPosition.X == 0 || move.NewPosition.X == 2)
                         {
+                            move.Parameter = new MoveCastle(CastleType.Queen);
+
                             if (!HasRightToCastle(PieceColor.White, CastleType.Queen, board))
                                 return false;
 
                             if (board.pieces[0, 1] is null && board.pieces[0, 2] is null && board.pieces[0, 3] is null)
-                            {
-                                move.Parameter = new MoveCastle(CastleType.Queen);
                                 return true;
-                            }
                         }
                         // King Castle
                         else if (move.NewPosition.X == 7 || move.NewPosition.X == 6)
                         {
+                            move.Parameter = new MoveCastle(CastleType.King);
+
                             if (!HasRightToCastle(PieceColor.White, CastleType.King, board))
                                 return false;
 
                             if (board.pieces[0, 5] is null && board.pieces[0, 6] is null)
-                            {
-                                move.Parameter = new MoveCastle(CastleType.King);
                                 return true;
-                            }
                         }
                         break;
                     case var e when e.Equals(PieceColor.Black):
                         // Queen Castle
                         if (move.NewPosition.X == 0 || move.NewPosition.X == 2)
                         {
+                            move.Parameter = new MoveCastle(CastleType.Queen);
+
                             if (!HasRightToCastle(PieceColor.Black, CastleType.Queen, board))
                                 return false;
 
                             if (board.pieces[7, 1] is null && board.pieces[7, 2] is null && board.pieces[7, 3] is null)
-                            {
-                                move.Parameter = new MoveCastle(CastleType.Queen);
                                 return true;
-                            }
                         }
                         // King Castle
                         else if (move.NewPosition.X == 7 || move.NewPosition.X == 6)
                         {
+                            move.Parameter = new MoveCastle(CastleType.King);
+
                             if (!HasRightToCastle(PieceColor.Black, CastleType.King, board))
                                 return false;
 
                             if (board.pieces[7, 5] is null && board.pieces[7, 6] is null)
-                            {
-                                move.Parameter = new MoveCastle(CastleType.King);
                                 return true;
-                            }
                         }
                         break;
                 }


### PR DESCRIPTION
This is not a pretty fix because of how Board.IsValidMove populates the move. I see there's refactoring work on the dev branch so perhaps this fix will eventually not be needed, but at least the test would be worth keeping.