### PR TITLE
Fixed bug in SAN conversion and added tests.

### DIFF
--- a/Chess.Tests/MoveTests.cs
+++ b/Chess.Tests/MoveTests.cs
@@ -109,6 +109,19 @@ public class MoveTests
         Assert.Equal(expectedSan, board.ExecutedMoves[0].San);
     }
 
+    [Theory]
+    [InlineData("4k3/8/8/8/3N4/8/3N4/4K1N1 w - - 0 1", "N2f3", "4k3/8/8/8/3N4/5N2/8/4K1N1 b - - 1 1")]
+    [InlineData("4k3/8/8/8/3N4/8/3N4/4K1N1 w - - 0 1", "Nd2f3", "4k3/8/8/8/3N4/5N2/8/4K1N1 b - - 1 1")]
+    [InlineData("4k3/8/8/8/8/8/3N3N/4K1N1 w - - 0 1", "Ndf3", "4k3/8/8/8/8/5N2/7N/4K1N1 b - - 1 1")]
+    [InlineData("4k3/8/8/8/8/8/3N3N/4K1N1 w - - 0 1", "Nd2f3", "4k3/8/8/8/8/5N2/7N/4K1N1 b - - 1 1")]
+    [InlineData("4k3/8/8/8/3N4/8/3N3N/4K3 w - - 0 1", "Nd2f3", "4k3/8/8/8/3N4/5N2/7N/4K3 b - - 1 1")]
+    public void TestAmbiguousMoveExecution(string fen, string san, string expectedFen)
+    {
+        var board = ChessBoard.LoadFromFen(fen);
+        board.Move(san);
+        Assert.Equal(expectedFen, board.ToFen());
+    }
+
     [Fact]
     public void TestParseToSan()
     {

--- a/ChessLibrary/Builders/SanBuilder.cs
+++ b/ChessLibrary/Builders/SanBuilder.cs
@@ -95,7 +95,7 @@ internal static class SanBuilder
 
         if (move.OriginalPosition.HasValueX)
             ambiguousMoves.RemoveAll(m => m.OriginalPosition.X != move.OriginalPosition.X);
-        else if (move.OriginalPosition.HasValueY)
+        if (move.OriginalPosition.HasValueY)
             ambiguousMoves.RemoveAll(m => m.OriginalPosition.Y != move.OriginalPosition.Y);
 
         if (ambiguousMoves.Count != 1)


### PR DESCRIPTION
The issue was that if a file was specified in the move notation, the program would just ignore the rank that was also specified. In those cases, if the file wasn't enough to resolve the ambiguity the conversion would fail, even if it was followed by a rank that would have resolved it.
E.g. if the SAN input was Nd2f3, the program would treat it like "Ndf3" when trying to resolve the move ambiguity.

I've added a test that checks if common ambiguous move scenarios work both with the optimal and the overly detailed SAN.

Closes #21 